### PR TITLE
Release GIL while PyTorchStreamWriter::writeEndOfFile

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1471,7 +1471,7 @@ void initJITBindings(PyObject* module) {
             return self.writeRecord(
                 name, reinterpret_cast<const char*>(data), size);
           })
-      .def("write_end_of_file", &PyTorchStreamWriter::writeEndOfFile)
+      .def("write_end_of_file", &PyTorchStreamWriter::writeEndOfFile, py::call_guard<py::gil_scoped_release>())
       .def("set_min_version", &PyTorchStreamWriter::setMinVersion)
       .def("archive_name", &PyTorchStreamWriter::archiveName)
       .def("serialization_id", &PyTorchStreamWriter::serializationId)


### PR DESCRIPTION
Fix latency in the next training iterations while using the torch async save feature.

Refs: AIS-192